### PR TITLE
security: pin GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@main
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: xibo-players/.github/.github/workflows/create-release.yml@main
+    uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'


### PR DESCRIPTION
Closes #37. Pins workflow action references to full commit SHAs with inline version comments. See xiboplayer-kiosk#29 / xiboplayer-kiosk#48 for the reference pattern.