### PR TITLE
ci(test): add cargo test + clippy workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: cargo test + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            g++ \
+            libdbus-1-dev \
+            libzmq3-dev \
+            qt6-webengine-dev \
+            libudev-dev \
+            pkg-config
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo build
+        run: cargo build --all-features
+
+      - name: cargo test
+        run: cargo test --all-features
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           components: clippy
 
+      - name: Force rustup stable on PATH (ubuntu-latest ships old system cargo)
+        # Without this, `cargo build` invokes /usr/bin/cargo (1.75) which
+        # doesn't support edition2024 and breaks on modern crates.
+        run: |
+          rustup default stable
+          rustup show
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Cache cargo build artifacts
         uses: Swatinem/rust-cache@v2
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,7 @@
 [toolchain]
-channel = "1.75.0"
+# Upstream pins 1.75.0 (Nov 2023) but transitive deps now require
+# edition2024, which only stabilised in Cargo 1.85 (Feb 2025).
+# Our fork uses "stable" so CI + local builds track whatever Rust
+# is current. Revisit only if we pick up a nightly-only feature or
+# need MSRV guarantees for a downstream consumer.
+channel = "stable"

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -333,7 +333,7 @@ impl Handler {
     fn schedule_check(&mut self) {
         let new_layouts = self.schedule.layouts_now();
         if new_layouts != self.layouts {
-            log::info!("new layouts in schedule: {}", new_layouts.iter().format(", ").to_string());
+            log::info!("new layouts in schedule: {}", new_layouts.iter().format(", "));
             self.to_gui.send(ToGui::Layouts(new_layouts.clone())).unwrap();
             self.layouts = new_layouts;
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -70,7 +70,7 @@ impl Server {
                 let path = dir.join(&parts[0][1..]);
 
                 let canonical_path = match path.canonicalize() {
-                    Ok(p) if p.starts_with(&dir) => p,
+                    Ok(p) if p.starts_with(dir) => p,
                     Ok(_) => {
                         log::warn!("processing HTTP req {}: 403 path outside cache dir", req.url());
                         return Ok(Response::empty(403).boxed());


### PR DESCRIPTION
## Summary

Closes the CI gap surfaced when PR #49 merged without its tests ever running.

The repo currently ships three artefact-building workflows (`deb.yml`, `rpm.yml`, `release.yml`) plus CodeQL scoped to GitHub Actions — none of them run `cargo test`. The unit tests added in PR #49 (hygiene-7fixes) were therefore never executed on CI before or after merge.

This adds a minimal `test.yml` that on every push to `master` and every pull request:

- installs the Qt6 / zmq / dbus / udev system deps the build needs on ubuntu-latest
- pins Rust stable via `dtolnay/rust-toolchain`
- caches `target/` via `Swatinem/rust-cache`
- runs `cargo build --all-features`, `cargo test --all-features`, and `cargo clippy --all-targets --all-features -- -D warnings`

## Test plan

- [ ] Workflow triggers on this PR and completes (green or flags real issues)
- [ ] Subsequent PRs automatically get the same gate