### PR TITLE
ci: opt into Node 24 JS actions globally

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Monday 06:00 UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -5,6 +5,9 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -5,6 +5,9 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Silences the recurring `Node.js 20 actions are deprecated … set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable` warning that fires on every workflow run.

Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: \"true\"` at the workflow `env:` level in all 5 workflows:

- `codeql.yml` (new env block)
- `deb.yml` (new env block)
- `release.yml` (new env block)
- `rpm.yml` (new env block)
- `test.yml` (new env block)

## Upstream-PR candidate

This change is generic CI hygiene, not fork-specific. It is a candidate for offering upstream to `birkenfeld/arexibo` (pending maintainer decision). Not offered yet.

## Test plan

- [ ] Verify this PR run no longer prints the Node 20 deprecation warning
- [ ] Confirm all 5 workflows still pass (no behavioural change expected)