### PR TITLE
chore: rename xibo-players GH org references → xiboplayer

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'

--- a/FORK-STATUS.md
+++ b/FORK-STATUS.md
@@ -1,4 +1,4 @@
-# Fork status — `xibo-players/arexibo`
+# Fork status — `xiboplayer/arexibo`
 
 This is a fork of [`birkenfeld/arexibo`](https://github.com/birkenfeld/arexibo),
 the original Rust/Qt6 Xibo signage player for Linux (primarily Raspberry Pi).
@@ -79,7 +79,7 @@ Dependabot bumps (`f7ec095`, `30b6756`, etc.) — replay as they appear upstream
    redundant (upstream implemented the same fix differently) — do NOT
    silently carry them as duplicates.
 3. **When opening an upstream PR**, do it from our fork directly:
-   `xibo-players/arexibo` is the GitHub-recognised fork of
+   `xiboplayer/arexibo` is the GitHub-recognised fork of
    `birkenfeld/arexibo` (`linuxnow/arexibo` redirects to us — the
    linuxnow repo was transferred to the org during the account
    consolidation; compare-URLs only work from the `xibo-players`
@@ -92,4 +92,4 @@ Dependabot bumps (`f7ec095`, `30b6756`, etc.) — replay as they appear upstream
 
 Primary point of contact for this fork: Pau Aliagas <pau@xiboplayer.org>.
 Discussion of upstreaming strategy: private in
-`xibo-players/xiboplayer-compliance` (tracking issue #TBD).
+`xiboplayer/xiboplayer-compliance` (tracking issue #TBD).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Binary builds are published on every tagged release:
   rebuild from source without running the full Cargo toolchain directly.
 
 Install from the xiboplayer package repos listed at
-<https://xibo-players.github.io/>.
+<https://xiboplayer.github.io/>.
 
 To build from source, you need:
 
@@ -126,7 +126,7 @@ for a version that hasn't been released yet:
 
 ```bash
 # 1. Clone the repo and check out the version you want
-git clone https://github.com/xibo-players/arexibo.git
+git clone https://github.com/xiboplayer/arexibo.git
 cd arexibo
 git checkout v0.3.3           # or any tag / commit
 

--- a/rpm/arexibo.spec
+++ b/rpm/arexibo.spec
@@ -6,7 +6,7 @@ Release:        3%{?dist}
 Summary:        Rust-based digital signage player for Xibo CMS
 
 License:        AGPLv3+
-URL:            https://github.com/xibo-players/arexibo
+URL:            https://github.com/xiboplayer/arexibo
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  rust >= 1.75


### PR DESCRIPTION
Pure rename sweep, fork of upstream arexibo. Companion across sibling repos.