### PR TITLE
feat(rpm): add Fedora 44 to build matrix

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'
-      fedora-matrix: '["43"]'
+      fedora-matrix: '["43", "44"]'
       arch-matrix: '["x86_64", "aarch64"]'
       source-tarball: 'full'
       gpg-sign: true


### PR DESCRIPTION
Closes #63.

## Summary

One-line change extending `arexibo/.github/workflows/rpm.yml`'s `fedora-matrix` from `["43"]` to `["43", "44"]`.

Why arexibo first (smallest blast to validate F44 in the shared `build-rpm.yml` reusable): pure Rust, no Node deps, no Chromium pin. Once this lands green, the same one-line change can roll out to xiboplayer-kiosk, xiboplayer-electron, xiboplayer-chromium, xiboplayer-chrome, xiboplayer-tizen, xiboplayer-webos in follow-up PRs.

Pre-flight checks captured in #63:

- Spec uses `Release: 3%{?dist}` — `.fc44.` naming is automatic.
- F44 base packages (`rust`, `cargo`, `dbus-devel`, `zeromq-devel`, `qt6-qtwebengine-devel`) all resolvable per the overnight audit (D3).
- Shared `build-rpm.yml` already declares `FEDORA_VERS="43 44"` in its R2 upload step — no reusable-workflow change required.
- `xiboplayer-release-44-7.fc44.noarch.rpm` is already live on R2.

## Test plan

- [ ] After merge: push a patch tag (e.g. `v0.3.3-4`) to trigger the workflow.
- [ ] Confirm both `arexibo-0.3.3-N.fc43.{x86_64,aarch64}.rpm` and `arexibo-0.3.3-N.fc44.{x86_64,aarch64}.rpm` land on R2.
- [ ] Confirm `update-repos.yml` on `xiboplayer.github.io` regenerates F44 repodata.
- [ ] On a Fedora 44 box: `sudo dnf install https://dl.xiboplayer.org/rpm/fedora/44/noarch/xiboplayer-release-44-7.fc44.noarch.rpm && sudo dnf install arexibo` should succeed.

## Risk

Low. Build matrix change only. F44 build failures don't block F43 builds (parallel matrix).

## Follow-ups (out of scope)

- Roll out the same matrix bump to the remaining form-factor repos once this PR validates F44 end-to-end.
- D3 flagged a soft caveat on `nodejs`/`nodejs-libs` for F44 — kiosk/electron/chromium PRs should pin explicit `nodejs22` when they extend.