### PR TITLE
chore(dependabot): scope to github-actions only, drop cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
 version: 2
 updates:
+  # Track our fork-local CI infra (workflow action SHAs).
+  # We do NOT track cargo dependencies: this fork follows upstream
+  # birkenfeld/arexibo for source code, and Cargo.toml / Cargo.lock
+  # are upstream's territory — re-bumping crates here just diverges us
+  # from upstream for no benefit. Crate bumps replay automatically the
+  # next time we rebase on upstream.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Closes #65.

## Summary

Drop the `cargo` ecosystem from `.github/dependabot.yml`. Keep `github-actions`.

Why: this fork tracks upstream `birkenfeld/arexibo` for source code. Bumping crates here just diverges us from upstream for no benefit. Our `.github/workflows/` are entirely fork-local (RPM/DEB packaging + release machinery), so workflow action SHA bumps remain genuinely our infra to track — those stay.

Companion: 8 open cargo dependabot PRs (#62 shlex, #57 nix, #54 subprocess, #53 dbus, #48 clap, #47 rand, #43 indexmap, #40 cargo group) will be closed once this lands. The 3 reusable-pin bumps (#56 build-deb, #59 build-rpm, #61 create-release) are replaced by a manual companion PR — see #66.

## Test plan

- [x] `.github/dependabot.yml` parses (yaml syntax).
- [ ] After merge: no new `chore(deps): bump <cargo-crate>` PRs will appear from dependabot.
- [ ] `chore(deps): bump <github-action>` PRs continue to appear weekly (verifies the github-actions ecosystem still works).

## Risk

Zero. Single-file metadata change. Reversible by re-adding the block.