### PR TITLE
ci: bump xiboplayer/.github reusable pins past org-rename URL fix

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    uses: xiboplayer/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/build-deb.yml@46da335eed4b80fcc1bb8015686152b4290f7617  # main
     with:
       package-name: arexibo
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   release:
-    uses: xiboplayer/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/create-release.yml@46da335eed4b80fcc1bb8015686152b4290f7617  # main
     with:
       package-name: arexibo
       description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@46da335eed4b80fcc1bb8015686152b4290f7617  # main
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'


### PR DESCRIPTION
Closes #66.

## Summary

Bump rpm.yml + deb.yml + release.yml from `5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4` (2026-04-09) to `46da335eed4b80fcc1bb8015686152b4290f7617` (2026-05-11, current HEAD of dot-github main).

The post-rename anchor includes dot-github commit `c85d100 chore(workflows): point dispatch URLs at renamed gh-pages repo` (2026-05-08), which patches the `notify` step curl POST URL from the pre-rename `xibo-players/xibo-players.github.io/dispatches` to `xiboplayer/xiboplayer.github.io/dispatches`. Until this bump, every tag-triggered build on arexibo silently dropped the update-repos dispatch (HTTP 307 + `curl -sf` no-`-L` quirk) — see #66 for the full root-cause writeup.

Manual replacement for dependabot PRs #56 / #59 / #61 — same diff, our authorship, single load-bearing commit.

## Test plan

- [ ] After merge: push a no-op patch tag (e.g. `v0.3.3-4`) or `workflow_dispatch` on `rpm.yml`.
- [ ] Watch the `Trigger repository update` step log — should see HTTP 204 with no `documentation_url` JSON.
- [ ] Confirm `update-repos.yml` fires on `xiboplayer.github.io` shortly after.
- [ ] Confirm `dl.xiboplayer.org/rpm/fedora/43/x86_64/repodata/repomd.xml` last-modified advances past 2026-04-17.

## Risk

Low. Three-line change. The post-rename SHA is current `main` of dot-github (proven stable; the dependabot-bump CI runs against this same SHA were all green). If anything regresses, revert is trivial (re-pin to `5c3b3699cd`).

## Companion

PR #X (`chore(dependabot): scope to github-actions only`) — together these complete the post-rename scope review for arexibo.